### PR TITLE
Align window size config

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ APP_VERSION = "1.2.0"
 APP_TITLE = "Music Picker"
 
 # 窗口配置
-WINDOW_GEOMETRY = "1280x960"  # 默认窗口大小
+WINDOW_GEOMETRY = "1280x1024"  # 默认窗口大小
 WINDOW_MIN_SIZE = (850, 650)  # 增加最小窗口尺寸，确保所有内容可见
 
 # 支持的音频格式


### PR DESCRIPTION
## Summary
- set `WINDOW_GEOMETRY` to 1280x1024

## Testing
- `python -m py_compile config.py gui.py MusicPicker.py music_processor.py playlist_generator.py playlist_comparator.py metadata_processor.py translator.py utils.py` *(fails: SyntaxError in music_processor.py)*

------
https://chatgpt.com/codex/tasks/task_b_68466506d27c8323a6fcba0699f92ec4