### PR TITLE
Fix main docstring formatting

### DIFF
--- a/MusicPicker.py
+++ b/MusicPicker.py
@@ -12,7 +12,8 @@ from utils import setup_logging
 
 
 def main():
-    """主函数"""    # 设置日志
+    """主函数"""
+    # 设置日志
     setup_logging()
     # 初始化翻译器
     translator = Translator()


### PR DESCRIPTION
## Summary
- separate the docstring from the logging comment in `main`

## Testing
- `python -m py_compile MusicPicker.py`
- `python MusicPicker.py` *(fails: unterminated string in music_processor.py)*

------
https://chatgpt.com/codex/tasks/task_b_68466792d79c8323870dc195d2bf0f30