### PR TITLE
Add subdirectory control for scanning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,7 @@ personal_*.txt
 
 # 开发和测试临时文件
 test_*.py
+!tests/test_playlist_generator.py
 temp_*.py
 debug_*.py
 

--- a/playlist_generator.py
+++ b/playlist_generator.py
@@ -35,12 +35,14 @@ class PlaylistGenerator:
         """默认日志输出"""
         self.logger.info(message)
 
-    def scan_music_folder(self, folder_path: str) -> List[str]:
+    def scan_music_folder(self, folder_path: str,
+                          include_subdirs: bool = True) -> List[str]:
         """
         扫描文件夹中的音乐文件
 
         Args:
             folder_path: 音乐文件夹路径
+            include_subdirs: 是否包含子目录
 
         Returns:
             音乐文件路径列表
@@ -51,11 +53,19 @@ class PlaylistGenerator:
 
         music_files = []
         try:
-            for root, dirs, files in os.walk(folder_path):
-                for file in files:
-                    if any(file.lower().endswith(ext)
-                           for ext in SUPPORTED_AUDIO_FORMATS):
-                        file_path = os.path.join(root, file)
+            if include_subdirs:
+                for root, dirs, files in os.walk(folder_path):
+                    for file in files:
+                        if any(file.lower().endswith(ext)
+                               for ext in SUPPORTED_AUDIO_FORMATS):
+                            file_path = os.path.join(root, file)
+                            music_files.append(file_path)
+            else:
+                for file in os.listdir(folder_path):
+                    file_path = os.path.join(folder_path, file)
+                    if (os.path.isfile(file_path) and
+                            any(file.lower().endswith(ext)
+                                for ext in SUPPORTED_AUDIO_FORMATS)):
                         music_files.append(file_path)
 
             self.log_callback(f"扫描完成，找到 {len(music_files)} 个音乐文件")
@@ -138,7 +148,8 @@ class PlaylistGenerator:
             return False
 
         self.log_callback(f"开始扫描文件夹: {folder_path}")
-        music_files = self.scan_music_folder(folder_path)
+        music_files = self.scan_music_folder(
+            folder_path, include_subdirs=include_subdirs)
 
         if not music_files:
             self.log_callback("文件夹中没有找到音乐文件")

--- a/tests/test_playlist_generator.py
+++ b/tests/test_playlist_generator.py
@@ -1,0 +1,51 @@
+import os
+import unittest
+import tempfile
+
+from playlist_generator import PlaylistGenerator
+
+class TestPlaylistGeneratorScanning(unittest.TestCase):
+    def setUp(self):
+        # create temporary directory structure
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        root_path = self.tmp_dir.name
+        self.root_file = os.path.join(root_path, "RootSong-Artist.mp3")
+        with open(self.root_file, "w") as f:
+            f.write("dummy")
+        self.sub_dir = os.path.join(root_path, "sub")
+        os.makedirs(self.sub_dir, exist_ok=True)
+        self.sub_file = os.path.join(self.sub_dir, "SubSong-Artist.mp3")
+        with open(self.sub_file, "w") as f:
+            f.write("dummy")
+        self.gen = PlaylistGenerator()
+        self.output_file = os.path.join(root_path, "playlist.txt")
+
+    def tearDown(self):
+        self.tmp_dir.cleanup()
+
+    def test_scan_without_subdirs(self):
+        files = self.gen.scan_music_folder(self.tmp_dir.name, include_subdirs=False)
+        self.assertIn(self.root_file, files)
+        self.assertNotIn(self.sub_file, files)
+
+    def test_scan_with_subdirs(self):
+        files = self.gen.scan_music_folder(self.tmp_dir.name, include_subdirs=True)
+        self.assertIn(self.root_file, files)
+        self.assertIn(self.sub_file, files)
+
+    def test_generate_playlist_without_subdirs(self):
+        self.gen.generate_playlist(self.tmp_dir.name, self.output_file,
+                                   include_subdirs=False)
+        with open(self.output_file, "r", encoding="utf-8") as f:
+            lines = [line.strip() for line in f.readlines() if not line.startswith("#") and line.strip()]
+        self.assertEqual(lines, ["RootSong - Artist"])
+
+    def test_generate_playlist_with_subdirs(self):
+        self.gen.generate_playlist(self.tmp_dir.name, self.output_file,
+                                   include_subdirs=True)
+        with open(self.output_file, "r", encoding="utf-8") as f:
+            lines = [line.strip() for line in f.readlines() if not line.startswith("#") and line.strip()]
+        self.assertEqual(set(lines), {"RootSong - Artist", "SubSong - Artist"})
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow skipping subdirectories when scanning music folders
- wire include_subdirs option through playlist generator
- add unit tests covering both scanning modes
- keep only desired test file in gitignore

## Testing
- `python -m unittest discover -v tests`

------
https://chatgpt.com/codex/tasks/task_b_68466794277c8323b1aa15763ac6de62